### PR TITLE
Fix trap! fn

### DIFF
--- a/src/main/clojure/co/paralleluniverse/pulsar/actors.clj
+++ b/src/main/clojure/co/paralleluniverse/pulsar/actors.clj
@@ -281,7 +281,7 @@
   and turn them into exit messages.
   Same as adding `:trap true` to `spawn`."
   []
-  (.setTrap ^PulsarActor @self true))
+  (.setTrap ^PulsarActor (Actor/currentActor) true))
 
 
 (ann link! (IFn [ActorRef -> ActorRef]


### PR DESCRIPTION
```@self ``` returns ActorRef which cannot be casted to PulsarActor. ```currentActor()``` on the other hand returns Actor, which can be casted.